### PR TITLE
Add `skip_unwrap_near` flag to swaps with near out

### DIFF
--- a/src/app/api/[[...slugs]]/route.ts
+++ b/src/app/api/[[...slugs]]/route.ts
@@ -8,7 +8,6 @@ import {
   instantSwap,
   nearDepositTransaction,
   nearWithdrawTransaction,
-  toReadableNumber,
   transformTransactions,
   type EstimateSwapView,
   type Transaction,
@@ -128,22 +127,13 @@ const app = new Elysia({ prefix: "/api", aot: false })
         // unwrap near
         const lastFunctionCall = transactionsRef[transactionsRef.length - 1]
           .functionCalls[0] as {
-          args: {
-            msg: string;
+            args: {
+              msg: string;
+            };
           };
-        };
         const parsedActions = JSON.parse(lastFunctionCall.args.msg);
-        const lastAction =
-          parsedActions.actions[parsedActions.actions.length - 1];
-        const amountOut = lastAction.min_amount_out;
-
-        const formattedAmountOut = toReadableNumber(
-          tokenOutData.decimals,
-          amountOut
-        );
-
-        const nearWithdrawTx = nearWithdrawTransaction(formattedAmountOut);
-        transactionsRef.push(nearWithdrawTx);
+        parsedActions['skip_unwrap_near'] = false;
+        lastFunctionCall.args.msg = JSON.stringify(parsedActions);
       }
 
       return transformTransactions(transactionsRef, accountId);


### PR DESCRIPTION
### **User description**
This flag, when false, unwraps all near going out of the swap on the ref contract. This way we don't have to know the amount to unwrap as the contract does it for us.


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a `skip_unwrap_near` flag set to `false` in the transaction message to handle NEAR unwrapping automatically.
- Removed the manual conversion of `amountOut` and the creation of a `nearWithdrawTransaction`, simplifying the transaction process.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Add `skip_unwrap_near` flag and remove manual unwrap logic</code></dd></summary>
<hr>

src/app/api/[[...slugs]]/route.ts

<li>Removed the conversion of <code>amountOut</code> to a readable number.<br> <li> Added <code>skip_unwrap_near</code> flag set to <code>false</code> in the transaction message.<br> <li> Removed the creation and addition of a <code>nearWithdrawTransaction</code>.


</details>


  </td>
  <td><a href="https://github.com/Mintbase/ref-finance-agent-next/pull/13/files#diff-0a875bfc2161e4d7540fbf8d9d80e3291fc7170148916f01e4ee045d9148e0b1">+5/-15</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

